### PR TITLE
2.2.0

### DIFF
--- a/.github/wiki/How-to-implement-your-own-device-with-Blu.md
+++ b/.github/wiki/How-to-implement-your-own-device-with-Blu.md
@@ -417,6 +417,7 @@ You can use the playground's extension mechanism to implement custom UI controls
 
 ### Bluetooth specification
 
+-   [Web Bluetooth Registries (Web Bluetooth CG)](https://github.com/WebBluetoothCG/registries)
 -   [List of assigned numbers, e.g. GATT UUIDs (Bluetooth SIG)](https://www.bluetooth.com/specifications/assigned-numbers/)
 -   [List of public Bluetooth specifications (Bluetooth SIG)](https://www.bluetooth.com/specifications/specs/)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,13 +23,13 @@
 				"eslint": "^8.51.0",
 				"eslint-config-prettier": "^9.0.0",
 				"eslint-plugin-tsdoc": "^0.2.17",
-				"html-bundler-webpack-plugin": "^2.14.3",
-				"npm-check-updates": "^16.14.5",
+				"html-bundler-webpack-plugin": "^2.14.4",
+				"npm-check-updates": "^16.14.6",
 				"prettier": "^3.0.3",
 				"terser-webpack-plugin": "^5.3.9",
 				"ts-loader": "^9.5.0",
 				"typescript": "^5.2.2",
-				"webpack": "^5.88.2",
+				"webpack": "^5.89.0",
 				"webpack-cli": "^5.1.4",
 				"webpack-dev-server": "^4.15.1",
 				"zod": "^3.22.4"
@@ -4155,9 +4155,9 @@
 			}
 		},
 		"node_modules/html-bundler-webpack-plugin": {
-			"version": "2.14.3",
-			"resolved": "https://registry.npmjs.org/html-bundler-webpack-plugin/-/html-bundler-webpack-plugin-2.14.3.tgz",
-			"integrity": "sha512-6izt4ruMPpJgYq/FwnoipcfgWLqL2vAUerrtWt+ikOaiiXFl61jGGv9iYt2kEf+Jd9c0CK990hx1GycbB/emJQ==",
+			"version": "2.14.4",
+			"resolved": "https://registry.npmjs.org/html-bundler-webpack-plugin/-/html-bundler-webpack-plugin-2.14.4.tgz",
+			"integrity": "sha512-2igfl/KQCTcg5U7Jfw10vvGcLhaacIuseIlMHxc9ZiAoMWWmpiBoYZhUnz/53nd7Ld4QGkFEcicktYuiqdik+w==",
 			"dev": true,
 			"dependencies": {
 				"ansis": "1.5.6",
@@ -5663,9 +5663,9 @@
 			}
 		},
 		"node_modules/npm-check-updates": {
-			"version": "16.14.5",
-			"resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.14.5.tgz",
-			"integrity": "sha512-f7v3YzPUgadtkB2LAVhiWMjrSejJ0N8OM9JjjVfxBz2neHqmPSWQUAUA+U/p3xeXHl9bghRD6knRqBhm9dkRGg==",
+			"version": "16.14.6",
+			"resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.14.6.tgz",
+			"integrity": "sha512-sJ6w4AmSDP7YzBXah94Ul2JhiIbjBDfx9XYgib15um2wtiQkOyjE7Lov3MNUSQ84Ry7T81mE4ynMbl/mGbK4HQ==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^5.3.0",
@@ -5673,7 +5673,7 @@
 				"commander": "^10.0.1",
 				"fast-memoize": "^2.5.2",
 				"find-up": "5.0.0",
-				"fp-and-or": "^0.1.3",
+				"fp-and-or": "^0.1.4",
 				"get-stdin": "^8.0.0",
 				"globby": "^11.0.4",
 				"hosted-git-info": "^5.1.0",
@@ -5691,11 +5691,11 @@
 				"prompts-ncu": "^3.0.0",
 				"rc-config-loader": "^4.1.3",
 				"remote-git-tags": "^3.0.0",
-				"rimraf": "^5.0.1",
+				"rimraf": "^5.0.5",
 				"semver": "^7.5.4",
 				"semver-utils": "^1.1.4",
 				"source-map-support": "^0.5.21",
-				"spawn-please": "^2.0.1",
+				"spawn-please": "^2.0.2",
 				"strip-ansi": "^7.1.0",
 				"strip-json-comments": "^5.0.1",
 				"untildify": "^4.0.0",
@@ -8788,9 +8788,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.88.2",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
-			"integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
+			"version": "5.89.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
+			"integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
 			"dev": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.3",

--- a/package.json
+++ b/package.json
@@ -47,15 +47,15 @@
 		"eslint-config-prettier": "^9.0.0",
 		"eslint-plugin-tsdoc": "^0.2.17",
 		"eslint": "^8.51.0",
-		"html-bundler-webpack-plugin": "^2.14.3",
-		"npm-check-updates": "^16.14.5",
+		"html-bundler-webpack-plugin": "^2.14.4",
+		"npm-check-updates": "^16.14.6",
 		"prettier": "^3.0.3",
 		"terser-webpack-plugin": "^5.3.9",
 		"ts-loader": "^9.5.0",
 		"typescript": "^5.2.2",
 		"webpack-cli": "^5.1.4",
 		"webpack-dev-server": "^4.15.1",
-		"webpack": "^5.88.2",
+		"webpack": "^5.89.0",
 		"zod": "^3.22.4"
 	},
 	"dependencies": {

--- a/src/characteristic.ts
+++ b/src/characteristic.ts
@@ -402,15 +402,17 @@ export default class BluCharacteristic extends BluEventEmitter<BluCharacteristic
 		if (!this.properties.notify) {
 			throw new BluCharacteristicOperationError(
 				this,
-				"Could not start listening to a non-notifying characteristic.",
+				"Could not start listening for notifications on a " +
+					"non-notifying characteristic.",
 			)
 		}
 
 		if (this.properties.isListening) {
 			throw new BluCharacteristicOperationError(
 				this,
-				"Could not start listening to a characteristic that is already " +
-					"listened to.",
+				"Could not start listening for notifications on a " +
+					"characteristic that is already listening for " +
+					"notifications.",
 			)
 		}
 
@@ -430,7 +432,7 @@ export default class BluCharacteristic extends BluEventEmitter<BluCharacteristic
 		} catch (error) {
 			throw new BluCharacteristicOperationError(
 				this,
-				"Could not start listening to characteristic.",
+				"Could not start listening for notifications.",
 				error,
 			)
 		}
@@ -446,8 +448,9 @@ export default class BluCharacteristic extends BluEventEmitter<BluCharacteristic
 		if (!this.properties.isListening) {
 			throw new BluCharacteristicOperationError(
 				this,
-				"Could not stop listening to a characteristic that is not yet " +
-					"listened to.",
+				"Could not stop listening for notifications on a " +
+					"characteristic that is not yet listening for " +
+					"notifications.",
 			)
 		}
 
@@ -467,7 +470,7 @@ export default class BluCharacteristic extends BluEventEmitter<BluCharacteristic
 		} catch (error) {
 			throw new BluCharacteristicOperationError(
 				this,
-				"Could not stop listening to characteristic.",
+				"Could not stop listening for notifications.",
 				error,
 			)
 		}
@@ -527,7 +530,7 @@ export class BluCharacteristicProperties {
 	readonly notify: boolean
 
 	/**
-	 * Is the characteristic currently listening to notifications?
+	 * Is the characteristic currently listening for notifications?
 	 * @remarks `undefined` if {@link BluCharacteristicProperties.notify} is
 	 *  `false`.
 	 */

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -163,6 +163,16 @@ export interface BluConfigurationOptions {
 	deviceProtocolMatching?: "default" | "minimal" | "off"
 
 	/**
+	 * The time to wait for a device connection to be established in
+	 * milliseconds before a connection attempt with {@link BluDevice.connect}
+	 * fails.
+	 * @remarks Can be `false` (no timeout, i.e. wait indefinitely) or a
+	 *  `number` of milliseconds.
+	 * @defaultValue `false`
+	 */
+	deviceConnectionTimeout?: number | false
+
+	/**
 	 * Automatically listen to notifiable characteristics?
 	 * @remarks Will be evaluated during protocol discovery, when connecting new
 	 *  devices. Can be a `boolean` value or an array of
@@ -256,6 +266,7 @@ const configurationOptionsGuard = z
 				z.literal("off"),
 			])
 			.default("default"),
+		deviceConnectionTimeout: z.number().or(z.literal(false)).default(false),
 		autoEnableNotifications: z
 			.boolean()
 			.or(z.array(z.string()))

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -16,8 +16,7 @@ export class BluConfiguration {
 	/**
 	 * Active configuration options.
 	 */
-	#options: Required<BluConfigurationOptions> =
-		configurationOptionsGuard.parse({})
+	#options = defaultOptions
 
 	/**
 	 * Active configuration options.
@@ -64,7 +63,7 @@ export class BluConfiguration {
 	 * Restore the default configuration.
 	 */
 	restoreDefaults() {
-		this.#options = configurationOptionsGuard.parse({})
+		this.#options = defaultOptions
 	}
 }
 
@@ -194,6 +193,18 @@ export interface BluConfigurationOptions {
 }
 
 /**
+ * Default configuration options for Blu.
+ */
+const defaultOptions: Required<BluConfigurationOptions> = {
+	scannerConfig: { acceptAllDevices: true },
+	deviceType: BluDevice,
+	deviceProtocolMatching: "default",
+	deviceConnectionTimeout: false,
+	autoEnableNotifications: true,
+	dataTransferLogging: false,
+}
+
+/**
  * A zod guard for configuration options.
  */
 const configurationOptionsGuard = z
@@ -253,25 +264,20 @@ const configurationOptionsGuard = z
 					optionalManufacturerData: z.array(z.number()).optional(),
 				}),
 			)
-			.default({ acceptAllDevices: true }),
+			.optional(),
 		deviceType: z
 			.custom<typeof BluDevice>(x => isSubclassOrSelf(x, BluDevice))
-			.default(() => {
-				return BluDevice
-			}),
+			.optional(),
 		deviceProtocolMatching: z
 			.union([
 				z.literal("default"),
 				z.literal("minimal"),
 				z.literal("off"),
 			])
-			.default("default"),
-		deviceConnectionTimeout: z.number().or(z.literal(false)).default(false),
-		autoEnableNotifications: z
-			.boolean()
-			.or(z.array(z.string()))
-			.default(true),
-		dataTransferLogging: z.boolean().default(false),
+			.optional(),
+		deviceConnectionTimeout: z.number().or(z.literal(false)).optional(),
+		autoEnableNotifications: z.boolean().or(z.array(z.string())).optional(),
+		dataTransferLogging: z.boolean().optional(),
 	})
 	.strict()
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -5,6 +5,7 @@ import isBufferSource from "./utils/isBufferSource"
 import isSubclassOrSelf from "./utils/isSubclassOrSelf"
 
 import type BluCharacteristic from "./characteristic"
+import type { BluProtocolDescription } from "./descriptions"
 
 /**
  * Configuration for Blu.
@@ -120,11 +121,12 @@ export interface BluConfigurationOptions {
 
 	/**
 	 * A device protocol matching type.
-	 * @remarks Instructs Blu how to handle discrepancies between the expected
+	 * @remarks Will be evaluated during protocol discovery, when connecting new
+	 *  devices. Instructs Blu how to handle discrepancies between the expected
 	 *  and actual Bluetooth protocols of devices when trying to connect them.
 	 *  The expected Bluetooth protocol is inferred from the
-	 *  {@link BluDevice.protocol} of the
-	 *  {@link BluConfigurationOptions.deviceType} protocol that was configured.
+	 *  {@link BluDevice.protocol} of the configured
+	 *  {@link BluConfigurationOptions.deviceType}.
 	 *
 	 *  **Available matching types**
 	 *
@@ -162,11 +164,15 @@ export interface BluConfigurationOptions {
 
 	/**
 	 * Automatically listen to notifiable characteristics?
-	 * @remarks If `false`, notifications have to be manually "enabled" by
-	 *  invoking {@link BluCharacteristic.startListeningForNotifications}.
+	 * @remarks Will be evaluated during protocol discovery, when connecting new
+	 *  devices. Can be a `boolean` value or an array of
+	 *  {@link BluProtocolDescription.identifier | characteristic identifiers}.
+	 *  If `false`, notifications have to be manually "enabled" for each
+	 *  characteristic by invoking
+	 *  {@link BluCharacteristic.startListeningForNotifications}.
 	 * @defaultValue `true`
 	 */
-	autoEnableNotifications?: boolean
+	autoEnableNotifications?: boolean | string[]
 
 	/**
 	 * Enable data transfer logging?
@@ -250,7 +256,10 @@ const configurationOptionsGuard = z
 				z.literal("off"),
 			])
 			.default("default"),
-		autoEnableNotifications: z.boolean().default(true),
+		autoEnableNotifications: z
+			.boolean()
+			.or(z.array(z.string()))
+			.default(true),
 		dataTransferLogging: z.boolean().default(false),
 	})
 	.strict()

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -1,0 +1,64 @@
+const textDecoder = new TextDecoder()
+
+/**
+ * Data converter.
+ * @sealed
+ * @public
+ */
+export class BluConverter {
+	toInt8Array(...data: number[]) {
+		return new Int8Array(data)
+	}
+
+	toUint8Array(...data: number[]) {
+		return new Uint8Array(data)
+	}
+
+	toUint8ClampedArray(...data: number[]) {
+		return new Uint8ClampedArray(data)
+	}
+
+	toInt16Array(...data: number[]) {
+		return new Int16Array(data)
+	}
+
+	toUint16Array(...data: number[]) {
+		return new Uint16Array(data)
+	}
+
+	toInt32Array(...data: number[]) {
+		return new Int32Array(data)
+	}
+
+	toUint32Array(...data: number[]) {
+		return new Uint32Array(data)
+	}
+
+	toFloat32Array(...data: number[]) {
+		return new Float32Array(data)
+	}
+
+	toFloat64Array(...data: number[]) {
+		return new Float64Array(data)
+	}
+
+	toBigInt64Array(...data: bigint[]) {
+		return new BigInt64Array(data)
+	}
+
+	toBigUint64Array(...data: bigint[]) {
+		return new BigUint64Array(data)
+	}
+
+	toString(data?: ArrayBuffer | ArrayBufferView) {
+		return textDecoder.decode(data)
+	}
+}
+
+/**
+ * Blu's global data converter.
+ * @remarks Handles everything related to data conversion.
+ * @public
+ */
+const convert = new BluConverter()
+export default convert

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -6,50 +6,98 @@ const textDecoder = new TextDecoder()
  * @public
  */
 export class BluConverter {
+	/**
+	 * Convert data to an `Int8Array`.
+	 * @param data - The data.
+	 */
 	toInt8Array(...data: number[]) {
 		return new Int8Array(data)
 	}
 
+	/**
+	 * Convert data to an `Uint8Array`.
+	 * @param data - The data.
+	 */
 	toUint8Array(...data: number[]) {
 		return new Uint8Array(data)
 	}
 
+	/**
+	 * Convert data to an `Uint8ClampedArray`.
+	 * @param data - The data.
+	 */
 	toUint8ClampedArray(...data: number[]) {
 		return new Uint8ClampedArray(data)
 	}
 
+	/**
+	 * Convert data to an `Int16Array`.
+	 * @param data - The data.
+	 */
 	toInt16Array(...data: number[]) {
 		return new Int16Array(data)
 	}
 
+	/**
+	 * Convert data to an `Uint16Array`.
+	 * @param data - The data.
+	 */
 	toUint16Array(...data: number[]) {
 		return new Uint16Array(data)
 	}
 
+	/**
+	 * Convert data to an `Int32Array`.
+	 * @param data - The data.
+	 */
 	toInt32Array(...data: number[]) {
 		return new Int32Array(data)
 	}
 
+	/**
+	 * Convert data to an `Uint32Array`.
+	 * @param data - The data.
+	 */
 	toUint32Array(...data: number[]) {
 		return new Uint32Array(data)
 	}
 
+	/**
+	 * Convert data to an `Float32Array`.
+	 * @param data - The data.
+	 */
 	toFloat32Array(...data: number[]) {
 		return new Float32Array(data)
 	}
 
+	/**
+	 * Convert data to an `Float64Array`.
+	 * @param data - The data.
+	 */
 	toFloat64Array(...data: number[]) {
 		return new Float64Array(data)
 	}
 
+	/**
+	 * Convert data to an `BigInt64Array`.
+	 * @param data - The data.
+	 */
 	toBigInt64Array(...data: bigint[]) {
 		return new BigInt64Array(data)
 	}
 
+	/**
+	 * Convert data to an `BigUint64Array`.
+	 * @param data - The data.
+	 */
 	toBigUint64Array(...data: bigint[]) {
 		return new BigUint64Array(data)
 	}
 
+	/**
+	 * Convert data to a string.
+	 * @param data - The data.
+	 */
 	toString(data?: ArrayBuffer | ArrayBufferView) {
 		return textDecoder.decode(data)
 	}

--- a/src/device.ts
+++ b/src/device.ts
@@ -212,6 +212,17 @@ export default class BluDevice extends BluEventEmitter<BluDeviceEvents> {
 
 			if (timeout) {
 				timeoutTimer = setTimeout(() => {
+					try {
+						this._bluetoothDevice.ongattserverdisconnected =
+							// eslint-disable-next-line @typescript-eslint/no-empty-function
+							() => {}
+
+						this.disconnect()
+					} catch {
+						// Ignore potential errors, as device is in unknown
+						// state and will be discarded anyways.
+					}
+
 					rejectWithError(
 						new BluDeviceConnectionTimeoutError(
 							`Connection attempt timed out after ${timeout} ms.`,

--- a/src/device.ts
+++ b/src/device.ts
@@ -533,8 +533,16 @@ export default class BluDevice extends BluEventEmitter<BluDeviceEvents> {
 						characteristic.properties.notify &&
 						configuration.options.autoEnableNotifications
 					) {
-						// Automatically listen to notifiable characteristics.
-						await characteristic.startListeningForNotifications()
+						if (
+							typeof configuration.options
+								.autoEnableNotifications === "boolean" ||
+							(characteristic.description.identifier &&
+								configuration.options.autoEnableNotifications.includes(
+									characteristic.description.identifier,
+								))
+						)
+							// Automatically listen to notifiable characteristics.
+							await characteristic.startListeningForNotifications()
 					}
 
 					for (const descriptor of characteristic.descriptors) {

--- a/src/device.ts
+++ b/src/device.ts
@@ -22,6 +22,8 @@ import logger from "./logger"
 import BluService from "./service"
 import isArray from "./utils/isArray"
 
+import type { BluConfigurationOptions } from "./configuration"
+
 /**
  * Bluetooth device.
  * @public
@@ -263,15 +265,17 @@ export default class BluDevice extends BluEventEmitter<BluDeviceEvents> {
 	 *  descriptors. Adds properties to {@link BluDevice} for all identifiable
 	 *  services. Adds properties to all {@link BluService}s for all identifiable
 	 *  characteristics. Adds properties to all {@link BluCharacteristic}s for all
-	 *  identifiable descriptors. Depending on the Blu configuration,
-	 *  auto-listens to any notifiable characteristics. Invokes all
+	 *  identifiable descriptors. Depending on the active {@link configuration}
+	 *  (see {@link BluConfigurationOptions.autoEnableNotifications | `autoEnableNotifications` option}),
+	 *  auto-listens to some or all notifiable characteristics. Invokes all
 	 *  `beforeReady` functions across the whole protocol and waits for them
 	 *  to be settled.
 	 * @throws A {@link BluDeviceProtocolDiscoveryError} when discovering the
 	 *  device's Bluetooth protocol is not possible.
 	 * @throws A {@link BluDeviceProtocolMatchingError} when the device's
-	 *  Bluetooth protocol does not match expectations, depending on the device
-	 *  protocol matching type set in the Blu configuration.
+	 *  Bluetooth protocol does not match expectations, depending on the
+	 *  {@link BluConfigurationOptions.deviceProtocolMatching | `deviceProtocolMatching` type}
+	 *  from the active {@link configuration}.
 	 */
 	async #discoverProtocol() {
 		try {

--- a/src/device.ts
+++ b/src/device.ts
@@ -308,7 +308,7 @@ export default class BluDevice extends BluEventEmitter<BluDeviceEvents> {
 
 					logger.warn(
 						`Could not discover "${serviceDescription.name}" ` +
-							`(${serviceDescription.uuid}).`,
+							`(UUID: ${serviceDescription.uuid}).`,
 						this,
 					)
 				}
@@ -358,9 +358,9 @@ export default class BluDevice extends BluEventEmitter<BluDeviceEvents> {
 
 							logger.warn(
 								`Could not discover "${characteristicDescription.name}" ` +
-									`(${characteristicDescription.uuid}) ` +
+									`(UUID: ${characteristicDescription.uuid}) ` +
 									`in "${serviceDescription.name}" ` +
-									`(${serviceDescription.uuid}).`,
+									`(UUID: ${serviceDescription.uuid}).`,
 								this,
 							)
 						}
@@ -400,9 +400,9 @@ export default class BluDevice extends BluEventEmitter<BluDeviceEvents> {
 
 									logger.warn(
 										`Could not discover "${descriptorDescription.name}" ` +
-											`(${descriptorDescription.uuid}) ` +
+											`(UUID: ${descriptorDescription.uuid}) ` +
 											`in "${characteristicDescription.name}" ` +
-											`(${characteristicDescription.uuid}).`,
+											`(UUID: ${characteristicDescription.uuid}).`,
 										this,
 									)
 								}

--- a/src/device.ts
+++ b/src/device.ts
@@ -230,7 +230,7 @@ export default class BluDevice extends BluEventEmitter<BluDeviceEvents> {
 					}
 
 					this.#discoverProtocol()
-						.then(() => {
+						.then(async () => {
 							if (isTimeoutReached) {
 								return
 							}
@@ -240,21 +240,22 @@ export default class BluDevice extends BluEventEmitter<BluDeviceEvents> {
 									this.#onDisconnected()
 								}
 
-							this.beforeReady()
-								?.then(() => {
-									if (isTimeoutReached) {
-										return
-									}
+							try {
+								await this.beforeReady()
+							} catch (error) {
+								rejectWithError(error)
+								return
+							}
 
-									clearTimeout(timeoutTimer)
+							if (isTimeoutReached) {
+								return
+							}
 
-									this.emit("connected")
+							clearTimeout(timeoutTimer)
 
-									resolve()
-								})
-								.catch(error => {
-									rejectWithError(error)
-								})
+							this.emit("connected")
+
+							resolve()
 						})
 						.catch(error => {
 							rejectWithError(error)

--- a/src/device.ts
+++ b/src/device.ts
@@ -247,7 +247,7 @@ export default class BluDevice extends BluEventEmitter<BluDeviceEvents> {
 	 * @remarks Queues the GATT operation and waits for it to resolve.
 	 * @typeParam ResultType - The type of the expected result.
 	 * @param operation - The GATT operation.
-	 * @returns The result of the GATT operation.
+	 * @returns A `Promise` that resolves with the result of the GATT operation.
 	 * @throws A {@link BluGATTOperationQueueError} when invalid arguments were
 	 *  provided.
 	 * @throws A {@link BluGATTOperationError} when the GATT operation fails.

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -200,6 +200,13 @@ export class BluDeviceConnectionError extends BluError {
 }
 
 /**
+ * Device connection timeout error.
+ * @sealed
+ * @public
+ */
+export class BluDeviceConnectionTimeoutError extends BluError {}
+
+/**
  * Device protocol discovery error.
  * @sealed
  * @public

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@
 
 import bluetooth from "./bluetooth"
 import configuration from "./configuration"
+import convert from "./converter"
 import logger from "./logger"
 import scanner from "./scanner"
 import version from "./version"
@@ -16,6 +17,7 @@ export {
 	BluCharacteristicProperties,
 } from "./characteristic"
 export { default as configuration } from "./configuration"
+export { default as convert } from "./converter"
 export * from "./descriptions"
 export { default as BluDescriptor } from "./descriptor"
 export { default as BluDevice } from "./device"
@@ -33,6 +35,7 @@ export { default as version } from "./version"
 export default {
 	bluetooth: bluetooth,
 	configuration: configuration,
+	convert: convert,
 	logger: logger,
 	scanner: scanner,
 	version: version,
@@ -41,6 +44,7 @@ export default {
 export type { BluBluetooth, BluBluetoothEvents } from "./bluetooth"
 export type { BluCharacteristicEvents } from "./characteristic"
 export type { BluConfiguration, BluConfigurationOptions } from "./configuration"
+export type { BluConverter } from "./converter"
 export type { BluDescriptorEvents } from "./descriptor"
 export type { BluDeviceEvents } from "./device"
 export type { BluEventEmitter, eventEmitter } from "./eventEmitter"

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,24 +10,20 @@ import logger from "./logger"
 import scanner from "./scanner"
 import version from "./version"
 
-export { BluBluetooth, default as bluetooth } from "./bluetooth"
+export { default as bluetooth } from "./bluetooth"
 export {
 	default as BluCharacteristic,
 	BluCharacteristicProperties,
 } from "./characteristic"
-export {
-	BluConfiguration,
-	BluConfigurationOptions,
-	default as configuration,
-} from "./configuration"
+export { default as configuration } from "./configuration"
 export * from "./descriptions"
 export { default as BluDescriptor } from "./descriptor"
 export { default as BluDevice } from "./device"
 export * from "./errors"
-export { BluLogger, default as logger } from "./logger"
+export { default as logger } from "./logger"
 export { default as BluRequest } from "./request"
 export { default as BluResponse } from "./response"
-export { BluScanner, default as scanner } from "./scanner"
+export { default as scanner } from "./scanner"
 export { default as BluService } from "./service"
 export { default as version } from "./version"
 
@@ -42,9 +38,12 @@ export default {
 	version: version,
 }
 
-export type { BluBluetoothEvents } from "./bluetooth"
+export type { BluBluetooth, BluBluetoothEvents } from "./bluetooth"
 export type { BluCharacteristicEvents } from "./characteristic"
+export type { BluConfiguration, BluConfigurationOptions } from "./configuration"
 export type { BluDescriptorEvents } from "./descriptor"
 export type { BluDeviceEvents } from "./device"
 export type { BluEventEmitter, eventEmitter } from "./eventEmitter"
+export type { BluLogger } from "./logger"
+export type { BluScanner } from "./scanner"
 export type { BluServiceEvents } from "./service"

--- a/src/playground/examples/battery/bluConfig.ts
+++ b/src/playground/examples/battery/bluConfig.ts
@@ -9,13 +9,13 @@ import { BatteryLevelCharacteristic, BatteryService } from "./battery"
 export class BatteryDevice extends BluDevice {
 	static override protocol = [
 		new BluServiceDescription({
-			uuid: 0x180f,
+			uuid: "0000180f-0000-1000-8000-00805f9b34fb",
 			identifier: "batteryService",
 			name: "Battery Service",
 			type: BatteryService,
 			characteristicDescriptions: [
 				new BluCharacteristicDescription({
-					uuid: 0x2a19,
+					uuid: "00002a19-0000-1000-8000-00805f9b34fb",
 					identifier: "batteryLevelCharacteristic",
 					name: "Battery Level Characteristic",
 					type: BatteryLevelCharacteristic,

--- a/src/playground/examples/battery/bluConfig.ts
+++ b/src/playground/examples/battery/bluConfig.ts
@@ -43,4 +43,5 @@ const scannerConfig: BluConfigurationOptions["scannerConfig"] = {
 export default {
 	scannerConfig: scannerConfig,
 	deviceType: BatteryDevice,
+	deviceConnectionTimeout: 10000,
 } as BluConfigurationOptions

--- a/src/playground/examples/microbit/accelerometer.ts
+++ b/src/playground/examples/microbit/accelerometer.ts
@@ -4,6 +4,7 @@ import {
 	BluService,
 	BluCharacteristicOperationError,
 	logger,
+	convert,
 } from "@blu.js/blu"
 
 export class AccelerometerService extends BluService {
@@ -142,7 +143,7 @@ export class AccelerometerPeriodCharacteristic extends BluCharacteristic {
 			)
 		}
 
-		await this.write(new Uint16Array([time]))
+		await this.write(convert.toUint16Array(time))
 
 		logger.debug(
 			`Set accelerometer period to ${time} ms.`,

--- a/src/playground/examples/microbit/bluConfig.ts
+++ b/src/playground/examples/microbit/bluConfig.ts
@@ -225,4 +225,5 @@ export default {
 	scannerConfig: scannerConfig,
 	deviceType: Microbit,
 	deviceProtocolMatching: "off",
+	deviceConnectionTimeout: 10000,
 } as BluConfigurationOptions

--- a/src/playground/examples/microbit/temperature.ts
+++ b/src/playground/examples/microbit/temperature.ts
@@ -4,6 +4,7 @@ import {
 	BluService,
 	BluCharacteristicOperationError,
 	logger,
+	convert,
 } from "@blu.js/blu"
 
 export class TemperatureService extends BluService {
@@ -98,7 +99,7 @@ export class TemperaturePeriodCharacteristic extends BluCharacteristic {
 		}
 
 		try {
-			await this.write(new Uint16Array([time]))
+			await this.write(convert.toUint16Array(time))
 
 			logger.debug(
 				`Set temperature period to ${time}ms.`,

--- a/src/playground/examples/starter-kit/bluConfig.ts
+++ b/src/playground/examples/starter-kit/bluConfig.ts
@@ -49,4 +49,5 @@ const scannerConfig: BluConfigurationOptions["scannerConfig"] = {
 export default {
 	scannerConfig: scannerConfig,
 	deviceType: MyDevice,
+	deviceConnectionTimeout: 10000,
 } as BluConfigurationOptions

--- a/src/playground/index.ts
+++ b/src/playground/index.ts
@@ -107,6 +107,8 @@ connectDeviceButton.addEventListener("click", () => {
 					onDisconnect()
 
 					blu.logger.error(error as Error)
+
+					return
 				}
 
 				window.device = device

--- a/src/playground/index.ts
+++ b/src/playground/index.ts
@@ -85,9 +85,29 @@ connectDeviceButton.addEventListener("click", () => {
 					"Blu Playground",
 				)
 
+				const onDisconnect = () => {
+					setCollectionVisibility("connection", false)
+
+					/**
+					 * Account for browser disconnect delay.
+					 * Could be removed, but reconnecting right away leads to
+					 * errors.
+					 */
+					setTimeout(() => {
+						connectDeviceButton.disabled = false
+						exampleSelect.disabled = false
+					}, 2500)
+				}
+
 				exampleSelect.disabled = true
 
-				await device.connect()
+				try {
+					await device.connect()
+				} catch (error) {
+					onDisconnect()
+
+					blu.logger.error(error as Error)
+				}
 
 				window.device = device
 
@@ -115,20 +135,6 @@ connectDeviceButton.addEventListener("click", () => {
 								}`,
 						)
 						.join("<br>")
-				}
-
-				function onDisconnect() {
-					setCollectionVisibility("connection", false)
-
-					/**
-					 * Account for browser disconnect delay.
-					 * Could be removed, but reconnecting right away leads to
-					 * errors.
-					 */
-					setTimeout(() => {
-						connectDeviceButton.disabled = false
-						exampleSelect.disabled = false
-					}, 2500)
 				}
 
 				device.once("disconnected", onDisconnect)

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -2,6 +2,7 @@ import bluetooth from "./bluetooth"
 import configuration from "./configuration"
 import { BluError, BluScannerError } from "./errors"
 
+import type { BluConfigurationOptions } from "./configuration"
 import type BluDevice from "./device"
 
 /**
@@ -13,9 +14,13 @@ export class BluScanner {
 	/**
 	 * Get a Bluetooth device.
 	 * @remarks Displays the browser's device chooser to the user, instructing
-	 *  them to pair a device.
-	 * @returns A `Promise` that resolves with the selected {@link BluDevice} of
-	 *  the configured type. `null` if no device was selected or found.
+	 *  them to pair a device. Filters advertising devices according to the
+	 *  {@link BluConfigurationOptions.scannerConfig | `scannerConfig`} from the
+	 *  active {@link configuration}.
+	 * @returns A `Promise` that resolves with the selected
+	 *  {@link BluDevice | device} of
+	 *  the {@link BluConfigurationOptions.deviceType | `deviceType`} from the
+	 *  active {@link configuration}. `null` if no device was selected or found.
 	 * @throws A {@link BluScannerError} when something went wrong.
 	 */
 	async getDevice() {


### PR DESCRIPTION
## ℹ️ About this PR

- Release 2.2.0

## 🚀 Features

### Data converter

[➡ Documentation](https://github.com/maxherrmann/blu/wiki/blu.bluconverter)

The new data converter can be used to convert various data.

#### Example: Convert multiple numbers to use them with `BluCharacteristic.write`
```ts
import { convert } from "@blu.js/blu"

// this: BluCharacteristic
await this.write(convert.toUint8Array(1, 2, 3))

// data: ArrayBuffer
return convert.toString(data)
```

### Device connection timeout

[➡ Documentation](https://github.com/maxherrmann/blu/wiki/blu.bluconfigurationoptions.deviceconnectiontimeout)

The new `deviceConnectionTimeout` configuration option allows you to set a timeout for device connection attempts. This is useful to handle scenarios in which a device may not respond to a connection attempt.

#### Example: Time-out connection attempts after 5 seconds
```ts
import { configuration } from "@blu.js/blu"

configuration.set({
  deviceConnectionTimeout: 5000
})
```

### Auto-listen to specific characteristics

[➡ Documentation](https://github.com/maxherrmann/blu/wiki/blu.bluconfigurationoptions.autoenablenotifications)

The `autoEnableNotifications` configuration option now allows you to provide an array of characteristic identifiers. This allows you to specify which characteristics Blu should auto-listen to.

#### Example: Only auto-listen to the "batteryLevel" characteristic
```ts
import { configuration } from "@blu.js/blu"

configuration.set({
  autoEnableNotifications: ["batteryLevel"]
})
```

## ✨ Enhancements

### Generic response types for characteristic request methods
The new generic `ResponseType` for `BluCharacteristic.request` and `ResponseTypes` for `BluCharacteristic.requestAll` eliminate the need to manually cast return values. When omitted, the generic type defaults to `BluResponse` for `BluCharacteristic.request` or `BluResponse[]` for `BluCharacteristic.requestAll`.

#### Before
```ts
// this: BluCharacteristic
const value = ((await this.request(new MyRequest()) as MyResponse).myValueProperty
```
#### After
```ts
// this: BluCharacteristic
const value = (await this.request<MyResponse>(new MyRequest())).myValueProperty
```

### Playground
- Examples now use registered Web Bluetooth UUIDs wherever applicable
- Connection attempts now time-out after 10 seconds

### Documentation
- Improved several warning and error messages
- Improved various TSDoc comments
- Added link to "Web Bluetooth Registries" to implementation guide

## ✅ Bug fixes

- Fixed: `configuration.set` method altered omitted options in some cases
- Fixed: Uncaught error when a GATT operation timeout out
- Fixed: Several issues with asynchronous functions not rejecting properly
- Fixed: `BluDevice.connect` did not handle errors while invoking `BluDevice.beforeReady`
- Fixed: Playground did not handle errors during device connection

## Other

- Cleaned up package exports
- Updated dependencies