### PR TITLE
2.3.0

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -1,4 +1,5 @@
 const textDecoder = new TextDecoder()
+const textEncoder = new TextEncoder()
 
 /**
  * Data converter.
@@ -10,7 +11,11 @@ export class BluConverter {
 	 * Convert data to an `Int8Array`.
 	 * @param data - The data.
 	 */
-	toInt8Array(...data: number[]) {
+	toInt8Array(data: number[] | number) {
+		if (typeof data === "number") {
+			data = [data]
+		}
+
 		return new Int8Array(data)
 	}
 
@@ -18,15 +23,28 @@ export class BluConverter {
 	 * Convert data to an `Uint8Array`.
 	 * @param data - The data.
 	 */
-	toUint8Array(...data: number[]) {
-		return new Uint8Array(data)
+	toUint8Array(data: number[] | number | string) {
+		if (typeof data === "number") {
+			data = [data]
+		}
+
+		switch (typeof data) {
+			case "string":
+				return textEncoder.encode(data)
+			case "object":
+				return new Uint8Array(data)
+		}
 	}
 
 	/**
 	 * Convert data to an `Uint8ClampedArray`.
 	 * @param data - The data.
 	 */
-	toUint8ClampedArray(...data: number[]) {
+	toUint8ClampedArray(data: number[] | number) {
+		if (typeof data === "number") {
+			data = [data]
+		}
+
 		return new Uint8ClampedArray(data)
 	}
 
@@ -34,7 +52,11 @@ export class BluConverter {
 	 * Convert data to an `Int16Array`.
 	 * @param data - The data.
 	 */
-	toInt16Array(...data: number[]) {
+	toInt16Array(data: number[] | number) {
+		if (typeof data === "number") {
+			data = [data]
+		}
+
 		return new Int16Array(data)
 	}
 
@@ -42,7 +64,11 @@ export class BluConverter {
 	 * Convert data to an `Uint16Array`.
 	 * @param data - The data.
 	 */
-	toUint16Array(...data: number[]) {
+	toUint16Array(data: number[] | number) {
+		if (typeof data === "number") {
+			data = [data]
+		}
+
 		return new Uint16Array(data)
 	}
 
@@ -50,7 +76,11 @@ export class BluConverter {
 	 * Convert data to an `Int32Array`.
 	 * @param data - The data.
 	 */
-	toInt32Array(...data: number[]) {
+	toInt32Array(data: number[] | number) {
+		if (typeof data === "number") {
+			data = [data]
+		}
+
 		return new Int32Array(data)
 	}
 
@@ -58,7 +88,11 @@ export class BluConverter {
 	 * Convert data to an `Uint32Array`.
 	 * @param data - The data.
 	 */
-	toUint32Array(...data: number[]) {
+	toUint32Array(data: number[] | number) {
+		if (typeof data === "number") {
+			data = [data]
+		}
+
 		return new Uint32Array(data)
 	}
 
@@ -66,7 +100,11 @@ export class BluConverter {
 	 * Convert data to an `Float32Array`.
 	 * @param data - The data.
 	 */
-	toFloat32Array(...data: number[]) {
+	toFloat32Array(data: number[] | number) {
+		if (typeof data === "number") {
+			data = [data]
+		}
+
 		return new Float32Array(data)
 	}
 
@@ -74,7 +112,11 @@ export class BluConverter {
 	 * Convert data to an `Float64Array`.
 	 * @param data - The data.
 	 */
-	toFloat64Array(...data: number[]) {
+	toFloat64Array(data: number[] | number) {
+		if (typeof data === "number") {
+			data = [data]
+		}
+
 		return new Float64Array(data)
 	}
 
@@ -82,7 +124,11 @@ export class BluConverter {
 	 * Convert data to an `BigInt64Array`.
 	 * @param data - The data.
 	 */
-	toBigInt64Array(...data: bigint[]) {
+	toBigInt64Array(data: bigint[] | bigint) {
+		if (typeof data === "bigint") {
+			data = [data]
+		}
+
 		return new BigInt64Array(data)
 	}
 
@@ -90,7 +136,11 @@ export class BluConverter {
 	 * Convert data to an `BigUint64Array`.
 	 * @param data - The data.
 	 */
-	toBigUint64Array(...data: bigint[]) {
+	toBigUint64Array(data: bigint[] | bigint) {
+		if (typeof data === "bigint") {
+			data = [data]
+		}
+
 		return new BigUint64Array(data)
 	}
 
@@ -98,7 +148,7 @@ export class BluConverter {
 	 * Convert data to a string.
 	 * @param data - The data.
 	 */
-	toString(data?: ArrayBuffer | ArrayBufferView) {
+	toString(data: ArrayBuffer | ArrayBufferView) {
 		return textDecoder.decode(data)
 	}
 }

--- a/src/device.ts
+++ b/src/device.ts
@@ -96,8 +96,8 @@ export default class BluDevice extends BluEventEmitter<BluDeviceEvents> {
 		}
 
 		if (
-			!isArray(configuration.options.deviceType.protocol) ||
-			configuration.options.deviceType.protocol.some(
+			!isArray((this.constructor as typeof BluDevice).protocol) ||
+			(this.constructor as typeof BluDevice).protocol.some(
 				element => !(element instanceof BluServiceDescription),
 			)
 		) {
@@ -351,8 +351,9 @@ export default class BluDevice extends BluEventEmitter<BluDeviceEvents> {
 
 			// Discover described services.
 
-			for (const serviceDescription of configuration.options.deviceType
-				.protocol) {
+			for (const serviceDescription of (
+				this.constructor as typeof BluDevice
+			).protocol) {
 				let service: BluService | undefined
 
 				try {

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -26,17 +26,14 @@ export class BluScanner {
 	 * @throws A {@link BluScannerError} when something went wrong.
 	 */
 	async getDevice<DeviceType extends BluDevice = BluDevice>() {
-		if (!bluetooth.isSupported) {
-			throw new BluScannerError(
-				"Could not get device.",
-				new BluError(
+		try {
+			if (!bluetooth.isSupported) {
+				throw new BluError(
 					"Blu is not compatible with this browser, because it " +
 						"does not support Web Bluetooth.",
-				),
-			)
-		}
+				)
+			}
 
-		try {
 			const webBluetoothDevice =
 				await globalThis.navigator.bluetooth.requestDevice(
 					configuration.options.scannerConfig,
@@ -46,6 +43,11 @@ export class BluScanner {
 				webBluetoothDevice,
 			) as DeviceType
 		} catch (error) {
+			if (error instanceof Error && error.name === "NotFoundError") {
+				// Device chooser has been closed on the client side.
+				return null
+			}
+
 			throw new BluScannerError("Could not get device.", error)
 		}
 	}

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -17,13 +17,15 @@ export class BluScanner {
 	 *  them to pair a device. Filters advertising devices according to the
 	 *  {@link BluConfigurationOptions.scannerConfig | `scannerConfig`} from the
 	 *  active {@link configuration}.
+	 * @typeParam DeviceType - The type of the returned device. Defaults to
+	 *  {@link BluDevice}.
 	 * @returns A `Promise` that resolves with the selected
-	 *  {@link BluDevice | device} of
-	 *  the {@link BluConfigurationOptions.deviceType | `deviceType`} from the
+	 *  {@link BluDevice | device} of the
+	 *  {@link BluConfigurationOptions.deviceType | `deviceType`} from the
 	 *  active {@link configuration}. `null` if no device was selected or found.
 	 * @throws A {@link BluScannerError} when something went wrong.
 	 */
-	async getDevice() {
+	async getDevice<DeviceType extends BluDevice = BluDevice>() {
 		if (!bluetooth.isSupported) {
 			throw new BluScannerError(
 				"Could not get device.",
@@ -40,7 +42,9 @@ export class BluScanner {
 					configuration.options.scannerConfig,
 				)
 
-			return new configuration.options.deviceType(webBluetoothDevice)
+			return new configuration.options.deviceType(
+				webBluetoothDevice,
+			) as DeviceType
 		} catch (error) {
 			throw new BluScannerError("Could not get device.", error)
 		}


### PR DESCRIPTION
## ℹ️ About this PR
- Release 2.3.0

## ✨ Enhancements

### Data converter
Data types for each `converter` method were updated to accept both data arrays and single data values.

### Generic device type for scanner
The new generic `DeviceType` for `scanner.getDevice()` eliminates the need to manually cast the return value. When omitted, the generic type defaults to `BluDevice`.

#### Before
```ts
const device = (await scanner.getDevice()) as MyDevice | null
```
#### After
```ts
const device = await scanner.getDevice<MyDevice>()
```

## ✅ Bug fixes
- Fixed: `scanner.getDevice()` did not resolve to `null` when no device was selected or found.
- Fixed: Device protocol discovery during `BluDevice.connect()` could use protocol descriptions from another device type. This happened when configuring a different `deviceType` after a device had been constructed, but not connected yet.
