### PR TITLE
4.2.1

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -205,7 +205,9 @@ export interface BluConfigurationOptions {
 	 * milliseconds before a connection attempt with {@link BluDevice.connect}
 	 * fails.
 	 * @remarks Can be `false` (no timeout, i.e. wait indefinitely) or a
-	 *  `number` of milliseconds.
+	 *  `number` of milliseconds. Keep in mind that the device connection
+	 *  time can vary depending on what tasks you run within the device's,
+	 *  service's, characteristic's or descriptor's `beforeReady()` hooks.
 	 * @defaultValue `false`
 	 */
 	deviceConnectionTimeout?: number | false

--- a/src/device.ts
+++ b/src/device.ts
@@ -484,11 +484,12 @@ export default class BluDevice<
 
 			let interfaceIncomplete = false
 
-			if (!this.isConnected) {
-				// Sometimes GATT server is reported as disconnected at this
-				// point. If that is the case, we try to reconnect first.
-				await this._bluetoothDevice.gatt?.connect()
-			}
+			// Sometimes GATT server is reported as disconnected at this
+			// point. If that is the case, we try to reconnect first.
+			// No need to check for `this.isConnected` here, because the
+			// `connect()` function resolves early when the device is already
+			// connected.
+			await this._bluetoothDevice.gatt?.connect()
 
 			if (this._bluetoothDevice.gatt === undefined) {
 				throw new BluDeviceInterfaceDiscoveryError(

--- a/src/device.ts
+++ b/src/device.ts
@@ -90,6 +90,11 @@ export default class BluDevice<
 	#willDisconnect = false
 
 	/**
+	 * Has the connection timeout been reached?
+	 */
+	#connectionTimeoutReached = false
+
+	/**
 	 * The number of interface discovery attempts.
 	 */
 	#interfaceDiscoveryAttempts = 0
@@ -179,9 +184,9 @@ export default class BluDevice<
 	 */
 	async connect() {
 		return new Promise<void>((resolve, reject) => {
-			const timeout = configuration.options.deviceConnectionTimeout
 			let timeoutTimer: ReturnType<typeof setTimeout>
-			let isTimeoutReached = false
+
+			this.#connectionTimeoutReached = false
 
 			const rejectWithError = (error: unknown) => {
 				try {
@@ -212,18 +217,22 @@ export default class BluDevice<
 				return
 			}
 
-			if (timeout) {
+			if (configuration.options.deviceConnectionTimeout) {
 				timeoutTimer = setTimeout(() => {
 					rejectWithError(
 						new BluDeviceConnectionTimeoutError(
 							this as never,
 							`Connection attempt timed out after ` +
-								`${String(timeout)} ms.`,
+								String(
+									configuration.options
+										.deviceConnectionTimeout,
+								) +
+								` ms.`,
 						),
 					)
 
-					isTimeoutReached = true
-				}, timeout)
+					this.#connectionTimeoutReached = true
+				}, configuration.options.deviceConnectionTimeout)
 			}
 
 			if (configuration.options.logging) {
@@ -235,13 +244,13 @@ export default class BluDevice<
 			this._bluetoothDevice.gatt
 				.connect()
 				.then(() => {
-					if (isTimeoutReached) {
+					if (this.#connectionTimeoutReached) {
 						return
 					}
 
 					this.#discoverInterface()
 						.then(async () => {
-							if (isTimeoutReached) {
+							if (this.#connectionTimeoutReached) {
 								return
 							}
 
@@ -451,6 +460,10 @@ export default class BluDevice<
 	 */
 	async #discoverInterface() {
 		try {
+			if (this.#connectionTimeoutReached) {
+				return
+			}
+
 			this.#interfaceDiscoveryAttempts++
 
 			if (configuration.options.logging) {


### PR DESCRIPTION
## ℹ️ About this PR
- Release 4.2.1

## ✨ Enhancements

### Improved handling of reconnection attempts during device interface discovery
It can happen that there are errors thrown while discovering a device's Bluetooth interface, that instruct the user to "Reconnect the device" due to the device's GATT server being reported as disconnected.

When trying to validate this by checking the `BluBluetoothRemoteGATTServer.connected` status flag, it appears that sometimes, in some browsers, the status flag wrongly reports the device as connected. If that was the case, Blu previously did not attempt to reconnect the device. 

Now, `BluBluetoothRemoteGATTServer.connect()` is called regardless of the status flag's current value.

### Documentation
- Improved some TSDoc comments

## ✅ Bug fixes
- Fixed: Device connection timeout was not respected when it has been reached during the discovery of a device's Bluetooth interface
